### PR TITLE
fix type of GET route to nextauth middleware

### DIFF
--- a/src/app/api/app/route.ts
+++ b/src/app/api/app/route.ts
@@ -17,4 +17,4 @@ export const GET = auth(async function GET(req) {
         return NextResponse.json(await res.json(), { status: res.status });
     }
     return NextResponse.json({ message: "Not authenticated" }, { status: 401 })
-})
+}) as any;


### PR DESCRIPTION
it won't build with a typeError

```
src/app/api/app/route.ts
Type error: Route "src/app/api/app/route.ts" has an invalid "GET" export:
  Type "AppRouteHandlerFnContext" is not a valid type for the function's second argument.
    Expected "Promise<any>", got "Awaitable<Record<string, string | string[]>>".
```